### PR TITLE
Fixed the version of font awesome to 4.7.  Anything later fails to bu…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "jquery-idletimer": "~0.9.2",
     "jquery-knob": "~1.2.3",
     "jquery-ui": "^1.12.1",
-    "font-awesome": "^4.7.0",
+    "font-awesome": "~4.7.0",
     "jquery-placeholder": "~2.0.8",
     "datatables.net": "^1.10.13",
     "jquery-tagit":"master"


### PR DESCRIPTION
Using the latest 4.x version of font awesome as specified in the bower file as "font-awesome": "^4.7.0" causes a error during build.  Forcing it to 4.7.x allows the build to succeed.  "font-awesome": "~4.7.0"